### PR TITLE
CR passed, after the longest government shutdown in US history

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,3 +1,3 @@
 {
-  "shutdownDate": "2025-10-01"
+  "shutdownDate": "2026-01-31"
 }

--- a/meta.js
+++ b/meta.js
@@ -1,2 +1,2 @@
-export const SHUTDOWN_DATE = "2025-10-01";
+export const SHUTDOWN_DATE = "2026-01-31";
 export const TIMEZONE = "America/New_York";


### PR DESCRIPTION
Shutdown began because Republicans are disgusting and don't think people should be able to afford healthcare. Shutdown ended because Democrats are craven plutocrats who ultimately agree.